### PR TITLE
feat#28: Implement Formation enum with conversion functions

### DIFF
--- a/contract/src/lib.cairo
+++ b/contract/src/lib.cairo
@@ -6,9 +6,9 @@ pub mod models {
     pub mod position;
     pub mod direction;
     pub mod directions_available;
+    pub mod formation;
     pub mod moves;
     pub mod vec2;
 }
 
-pub mod tests {
-}
+pub mod tests {}

--- a/contract/src/models/formation.cairo
+++ b/contract/src/models/formation.cairo
@@ -1,0 +1,139 @@
+use core::traits::Into;
+
+#[derive(Copy, Drop, Serde, PartialEq)]
+pub enum Formation {
+    F442, // 4-4-2
+    F433, // 4-3-3
+    F352, // 3-5-2
+    F343, // 3-4-3
+    F4231 // 4-2-3-1
+}
+
+pub impl IntoFormationFelt252 of Into<Formation, felt252> {
+    #[inline(always)]
+    fn into(self: Formation) -> felt252 {
+        match self {
+            Formation::F442 => '4-4-2',
+            Formation::F433 => '4-3-3',
+            Formation::F352 => '3-5-2',
+            Formation::F343 => '3-4-3',
+            Formation::F4231 => '4-2-3-1',
+        }
+    }
+}
+
+pub impl IntoFormationU8 of Into<Formation, u8> {
+    #[inline(always)]
+    fn into(self: Formation) -> u8 {
+        match self {
+            Formation::F442 => 1,
+            Formation::F433 => 2,
+            Formation::F352 => 3,
+            Formation::F343 => 4,
+            Formation::F4231 => 5,
+        }
+    }
+}
+
+pub impl IntoU8Formation of Into<u8, Formation> {
+    #[inline(always)]
+    fn into(self: u8) -> Formation {
+        match self {
+            0 => panic!("Invalid formation ID"),
+            1 => Formation::F442,
+            2 => Formation::F433,
+            3 => Formation::F352,
+            4 => Formation::F343,
+            5 => Formation::F4231,
+            _ => panic!("Invalid formation ID"),
+        }
+    }
+}
+
+// TODO: implement this function when the PlayerPosition enum is implemented.
+// Function to validate if a team's PlayerPositions match the expectedformation
+// pub fn is_valid_formation(positions: Array<PlayerPosition>, formation: Formation) -> bool {
+//
+// }
+
+#[cfg(test)]
+mod tests {
+    use super::{Formation};
+    use core::traits::Into;
+
+    #[test]
+    fn test_formation_to_felt252() {
+        let formation = Formation::F442;
+        let formation_str: felt252 = formation.into();
+        assert(formation_str == '4-4-2', 'F442 should be 4-4-2');
+
+        let formation = Formation::F433;
+        let formation_str: felt252 = formation.into();
+        assert(formation_str == '4-3-3', 'F433 should be 4-3-3');
+
+        let formation = Formation::F352;
+        let formation_str: felt252 = formation.into();
+        assert(formation_str == '3-5-2', 'F352 should be 3-5-2');
+
+        let formation = Formation::F343;
+        let formation_str: felt252 = formation.into();
+        assert(formation_str == '3-4-3', 'F343 should be 3-4-3');
+
+        let formation = Formation::F4231;
+        let formation_str: felt252 = formation.into();
+        assert(formation_str == '4-2-3-1', 'F4231 should be 4-2-3-1');
+    }
+
+    #[test]
+    fn test_formation_to_u8() {
+        let formation = Formation::F442;
+        let formation_u8: u8 = formation.into();
+        assert(formation_u8 == 1, 'F442 should be 1');
+
+        let formation = Formation::F433;
+        let formation_u8: u8 = formation.into();
+        assert(formation_u8 == 2, 'F433 should be 2');
+
+        let formation = Formation::F352;
+        let formation_u8: u8 = formation.into();
+        assert(formation_u8 == 3, 'F352 should be 3');
+
+        let formation = Formation::F343;
+        let formation_u8: u8 = formation.into();
+        assert(formation_u8 == 4, 'F343 should be 4');
+
+        let formation = Formation::F4231;
+        let formation_u8: u8 = formation.into();
+        assert(formation_u8 == 5, 'F4231 should be 5');
+    }
+
+    #[test]
+    fn test_u8_to_formation() {
+        let u8_value: u8 = 1;
+        let formation: Formation = u8_value.into();
+        assert(formation == Formation::F442, '1 should be F442');
+
+        let u8_value: u8 = 2;
+        let formation: Formation = u8_value.into();
+        assert(formation == Formation::F433, '2 should be F433');
+
+        let u8_value: u8 = 3;
+        let formation: Formation = u8_value.into();
+        assert(formation == Formation::F352, '3 should be F352');
+
+        let u8_value: u8 = 4;
+        let formation: Formation = u8_value.into();
+        assert(formation == Formation::F343, '4 should be F343');
+
+        let u8_value: u8 = 5;
+        let formation: Formation = u8_value.into();
+        assert(formation == Formation::F4231, '5 should be F4231');
+    }
+
+    #[test]
+    #[should_panic(expected: ("Invalid formation ID",))]
+    fn test_invalid_u8_to_formation() {
+        let u8_value: u8 = 10;
+        let _formation: Formation = u8_value.into();
+    }
+}


### PR DESCRIPTION
## Related issue #28 

## PR Description
This PR implements the Formation enum representing five popular football formations (4-4-2, 4-3-3, 3-5-2, 3-4-3, and 4-2-3-1). The implementation includes:

- Creation of the Formation enum with appropriate variants
- Conversion functions from Formation to felt252 (string representation)
- Conversion functions from Formation to u8 (numeric representation)
- Conversion functions from u8 back to Formation
- Comprehensive test suite for all conversion functions

## Additional notes
The utility function for validating if a team's player positions match a formation is included as a commented placeholder. This function can't be fully implemented yet since it's awaiting the PlayerPosition enum implementation (#25) , which is being handled separately. Once the PlayerPosition enum is available, the validation function can be properly implemented by uncommenting and completing the provided structure.

<img width="852" alt="Screenshot 2025-03-22 at 6 48 34" src="https://github.com/user-attachments/assets/83b020fa-86f9-46f5-8c1b-9b9777ce85a6" />
