### PR TITLE
feat: implement pseudo-random number generator

### DIFF
--- a/contract/src/helpers/pseudo_random.cairo
+++ b/contract/src/helpers/pseudo_random.cairo
@@ -1,0 +1,204 @@
+use core::pedersen::pedersen;
+use starknet::{get_block_timestamp, get_block_number};
+
+/// The PseudoRandom module provides deterministic randomness for Dojo games,
+/// allowing developers to generate random values for game mechanics based on
+/// Starknet block data like timestamp and block number for entropy.
+#[generate_trait]
+pub impl PseudoRandom of PseudoRandomTrait {
+    /// Generates a pseudo-random u8 value within the specified range [min, max] (inclusive).
+    ///
+    /// # Arguments
+    ///
+    /// * `min` - The minimum value (inclusive)
+    /// * `max` - The maximum value (inclusive)
+    /// * `salt` - An optional salt value to add more entropy
+    ///
+    /// # Returns
+    ///
+    /// A pseudo-random u8 value between min and max (inclusive)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use starkfantasy::helpers::pseudo_random::PseudoRandom;
+    ///
+    /// // Generate a random number between 1 and 100
+    /// let random_value = PseudoRandom::generate_random_u8(1, 100, 0);
+    /// ```
+    fn generate_random_u8(min: u8, max: u8, salt: felt252) -> u8 {
+        // Validate input range
+        assert(min <= max, 'Min must be <= max');
+
+        // Get entropy sources from Starknet
+        let timestamp = get_block_timestamp();
+        let block_number = get_block_number();
+
+        // Combine entropy sources with salt
+        let hash = pedersen(pedersen(timestamp.into(), block_number.into()), salt);
+        
+        // Convert the hash to a u8 value
+        let hash_u8: u8 = (hash % 256).try_into().unwrap();
+        
+        // Scale the result to fit within the provided range
+        min + (hash_u8 % (max - min + 1))
+    }
+    
+    /// Generates a pseudo-random u32 value within the specified range [min, max] (inclusive).
+    ///
+    /// # Arguments
+    ///
+    /// * `min` - The minimum value (inclusive)
+    /// * `max` - The maximum value (inclusive)
+    /// * `salt` - An optional salt value to add more entropy
+    ///
+    /// # Returns
+    ///
+    /// A pseudo-random u32 value between min and max (inclusive)
+    fn generate_random_u32(min: u32, max: u32, salt: felt252) -> u32 {
+        // Validate input range
+        assert(min <= max, 'Min must be <= max');
+
+        // Get entropy sources from Starknet
+        let timestamp = get_block_timestamp();
+        let block_number = get_block_number();
+
+        // Combine entropy sources with salt
+        let hash = pedersen(pedersen(timestamp.into(), block_number.into()), salt);
+        
+        // Convert the hash to a u32 value (take the lower 32 bits)
+        let hash_u32: u32 = (hash % 0x100000000).try_into().unwrap();
+        
+        // Scale the result to fit within the provided range
+        let range = max - min + 1;
+        min + (hash_u32 % range)
+    }
+    
+    /// Generates a pseudo-random u64 value within the specified range [min, max] (inclusive).
+    ///
+    /// # Arguments
+    ///
+    /// * `min` - The minimum value (inclusive)
+    /// * `max` - The maximum value (inclusive)
+    /// * `salt` - An optional salt value to add more entropy
+    ///
+    /// # Returns
+    ///
+    /// A pseudo-random u64 value between min and max (inclusive)
+    fn generate_random_u64(min: u64, max: u64, salt: felt252) -> u64 {
+        // Validate input range
+        assert(min <= max, 'Min must be <= max');
+
+        // Get entropy sources from Starknet
+        let timestamp = get_block_timestamp();
+        let block_number = get_block_number();
+
+        // Combine entropy sources with salt
+        let hash = pedersen(pedersen(timestamp.into(), block_number.into()), salt);
+        
+        // Convert the hash to a u64 value
+        let hash_u64: u64 = (hash % 0x10000000000000000).try_into().unwrap();
+        
+        // Scale the result to fit within the provided range
+        let range = max - min + 1;
+        min + (hash_u64 % range)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PseudoRandom;
+    use starknet::testing::set_block_timestamp;
+    use starknet::testing::set_block_number;
+
+    #[test]
+    fn test_generate_random_u8_in_range() {
+        // Set deterministic block values for testing
+        set_block_timestamp(1000);
+        set_block_number(500);
+        
+        // Generate random numbers with different ranges
+        let random1 = PseudoRandom::generate_random_u8(1, 10, 0);
+        let random2 = PseudoRandom::generate_random_u8(50, 100, 0);
+        let random3 = PseudoRandom::generate_random_u8(200, 255, 0);
+        
+        // Check that values are within the specified ranges
+        assert(random1 >= 1 && random1 <= 10, 'Value out of range 1-10');
+        assert(random2 >= 50 && random2 <= 100, 'Value out of range 50-100');
+        assert(random3 >= 200 && random3 <= 255, 'Value out of range 200-255');
+    }
+
+    #[test]
+    fn test_generate_random_u8_consistency() {
+        // Set deterministic block values for testing
+        set_block_timestamp(1000);
+        set_block_number(500);
+        
+        // Generate random numbers with the same inputs
+        let random1 = PseudoRandom::generate_random_u8(1, 100, 0);
+        let random2 = PseudoRandom::generate_random_u8(1, 100, 0);
+        
+        // They should be identical since inputs are the same
+        assert(random1 == random2, 'Should generate same value');
+        
+        // Generate with different salt
+        let random3 = PseudoRandom::generate_random_u8(1, 100, 123);
+        
+        // Should be different with different salt
+        assert(random1 != random3, 'Should be different with salt');
+    }
+
+    #[test]
+    fn test_generate_random_u8_edge_cases() {
+        // Test with min = max
+        let random = PseudoRandom::generate_random_u8(42, 42, 0);
+        assert(random == 42, 'Should return exactly 42');
+        
+        // Test with full range (0-255)
+        let random_full = PseudoRandom::generate_random_u8(0, 255, 0);
+        assert(random_full >= 0 && random_full <= 255, 'Should be in full range');
+    }
+    
+    #[test]
+    fn test_generate_random_u32() {
+        // Set deterministic block values for testing
+        set_block_timestamp(1000);
+        set_block_number(500);
+        
+        // Generate random u32 numbers
+        let random1 = PseudoRandom::generate_random_u32(1, 1000, 0);
+        let random2 = PseudoRandom::generate_random_u32(1, 1000, 1);
+        
+        // Check that values are within the specified range
+        assert(random1 >= 1 && random1 <= 1000, 'Value out of range 1-1000');
+        assert(random2 >= 1 && random2 <= 1000, 'Value out of range 1-1000');
+        
+        // Different salts should produce different results
+        assert(random1 != random2, 'Different salts -> different values');
+    }
+    
+    #[test]
+    fn test_generate_random_u64() {
+        // Set deterministic block values for testing
+        set_block_timestamp(1000);
+        set_block_number(500);
+        
+        // Generate random u64 numbers
+        let random1 = PseudoRandom::generate_random_u64(1, 10000, 0);
+        let random2 = PseudoRandom::generate_random_u64(1, 10000, 2);
+        
+        // Check that values are within the specified range
+        assert(random1 >= 1 && random1 <= 10000, 'Value out of range 1-10000');
+        assert(random2 >= 1 && random2 <= 10000, 'Value out of range 1-10000');
+        
+        // Different salts should produce different results
+        assert(random1 != random2, 'Different salts -> different values');
+    }
+    
+    #[test]
+    #[should_panic(expected: ('Min must be <= max',))]
+    fn test_invalid_range() {
+        // This should panic because min > max
+        PseudoRandom::generate_random_u8(100, 50, 0);
+    }
+} 

--- a/contract/src/helpers/pseudo_random.cairo
+++ b/contract/src/helpers/pseudo_random.cairo
@@ -1,4 +1,8 @@
-use core::pedersen::pedersen;
+// Core imports
+use core::hash::{HashStateTrait};
+use core::pedersen::PedersenTrait;
+
+// Starknet import
 use starknet::{get_block_timestamp, get_block_number};
 
 /// The PseudoRandom module provides deterministic randomness for Dojo games,
@@ -6,42 +10,52 @@ use starknet::{get_block_timestamp, get_block_number};
 /// Starknet block data like timestamp and block number for entropy.
 #[generate_trait]
 pub impl PseudoRandom of PseudoRandomTrait {
-    /// Generates a pseudo-random u8 value within the specified range [min, max] (inclusive).
-    ///
+    /// Generates a pseudo-random u8 number between min and max (inclusive)
+    /// 
     /// # Arguments
-    ///
-    /// * `min` - The minimum value (inclusive)
-    /// * `max` - The maximum value (inclusive)
-    /// * `salt` - An optional salt value to add more entropy
-    ///
+    /// * `unique_id` - Unique ID used to generate randomness
+    /// * `salt` - Unique salt value to generate randomness
+    /// * `min` - Minimum value for the range
+    /// * `max` - Maximum value for the range
+    /// 
     /// # Returns
-    ///
-    /// A pseudo-random u8 value between min and max (inclusive)
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use starkfantasy::helpers::pseudo_random::PseudoRandom;
-    ///
-    /// // Generate a random number between 1 and 100
-    /// let random_value = PseudoRandom::generate_random_u8(1, 100, 0);
-    /// ```
-    fn generate_random_u8(min: u8, max: u8, salt: felt252) -> u8 {
-        // Validate input range
-        assert(min <= max, 'Min must be <= max');
-
-        // Get entropy sources from Starknet
-        let timestamp = get_block_timestamp();
+    /// * `u8` - Random number between min and max
+    fn generate_random_u8(
+        unique_id: u16, 
+        salt: u16,
+        min: u8, 
+        max: u8
+    ) -> u8 {
+        // Obtain entropy values from the environment
+        let block_timestamp = get_block_timestamp();
         let block_number = get_block_number();
-
-        // Combine entropy sources with salt
-        let hash = pedersen(pedersen(timestamp.into(), block_number.into()), salt);
         
-        // Convert the hash to a u8 value
-        let hash_u8: u8 = (hash % 256).try_into().unwrap();
+        // Create unique seeds by combining different sources
+        let timestamp_seed: felt252 = block_timestamp.into() + salt.into();
+        let block_seed: felt252 = block_number.into() + unique_id.into();
+        let combined_seed: felt252 = timestamp_seed + (unique_id * salt).into();
         
-        // Scale the result to fit within the provided range
-        min + (hash_u8 % (max - min + 1))
+        // Combine the seeds
+        let hash_input = combined_seed + block_seed;
+        
+        // Use the Pedersen hash to generate a pseudo-random value
+        let hash_state = PedersenTrait::new(0);
+        let hash_state = hash_state.update(hash_input);
+        let hash = hash_state.finalize();
+        
+        // Convert the hash to a value between min and max
+        let range: u64 = (max - min + 1).into();
+        
+        // Convert hash to u256 to handle large values safely
+        let hash_u256: u256 = hash.into();
+        
+        // Take modulo to get a value within range
+        let mod_value: u64 = (hash_u256 % range.into()).try_into().unwrap();
+        
+        // Convert back to u8 and add min
+        let random_value: u8 = mod_value.try_into().unwrap() + min;
+        
+        return random_value;
     }
     
     /// Generates a pseudo-random u32 value within the specified range [min, max] (inclusive).
@@ -112,93 +126,63 @@ mod tests {
     use starknet::testing::set_block_number;
 
     #[test]
-    fn test_generate_random_u8_in_range() {
-        // Set deterministic block values for testing
-        set_block_timestamp(1000);
-        set_block_number(500);
+    #[available_gas(300000)]
+    fn test_random_generation() {
+        let min: u8 = 50;
+        let max: u8 = 90;
         
-        // Generate random numbers with different ranges
-        let random1 = PseudoRandom::generate_random_u8(1, 10, 0);
-        let random2 = PseudoRandom::generate_random_u8(50, 100, 0);
-        let random3 = PseudoRandom::generate_random_u8(200, 255, 0);
+        // Test with different beast IDs and attribute salts
+        let random1 = PseudoRandom::generate_random_u8(1, 1, min, max);
+        let random2 = PseudoRandom::generate_random_u8(2, 1, min, max);
+        let random3 = PseudoRandom::generate_random_u8(1, 2, min, max);
         
-        // Check that values are within the specified ranges
-        assert(random1 >= 1 && random1 <= 10, 'Value out of range 1-10');
-        assert(random2 >= 50 && random2 <= 100, 'Value out of range 50-100');
-        assert(random3 >= 200 && random3 <= 255, 'Value out of range 200-255');
-    }
-
-    #[test]
-    fn test_generate_random_u8_consistency() {
-        // Set deterministic block values for testing
-        set_block_timestamp(1000);
-        set_block_number(500);
+        // Check that values are within range
+        assert(random1 >= min && random1 <= max, 'Value out of range');
+        assert(random2 >= min && random2 <= max, 'Value out of range');
+        assert(random3 >= min && random3 <= max, 'Value out of range');
         
-        // Generate random numbers with the same inputs
-        let random1 = PseudoRandom::generate_random_u8(1, 100, 0);
-        let random2 = PseudoRandom::generate_random_u8(1, 100, 0);
-        
-        // They should be identical since inputs are the same
-        assert(random1 == random2, 'Should generate same value');
-        
-        // Generate with different salt
-        let random3 = PseudoRandom::generate_random_u8(1, 100, 123);
-        
-        // Should be different with different salt
-        assert(random1 != random3, 'Should be different with salt');
-    }
-
-    #[test]
-    fn test_generate_random_u8_edge_cases() {
-        // Test with min = max
-        let random = PseudoRandom::generate_random_u8(42, 42, 0);
-        assert(random == 42, 'Should return exactly 42');
-        
-        // Test with full range (0-255)
-        let random_full = PseudoRandom::generate_random_u8(0, 255, 0);
-        assert(random_full >= 0 && random_full <= 255, 'Should be in full range');
+        // Check that at least two values are different (collisions are possible)
+        let all_equal = random1 == random2 && random2 == random3;
+        assert(!all_equal, 'All values are the same');
     }
     
     #[test]
-    fn test_generate_random_u32() {
-        // Set deterministic block values for testing
-        set_block_timestamp(1000);
-        set_block_number(500);
+    #[available_gas(300000)]
+    fn test_different_attributes() {
+        let beast_id = 1_u16;
+        let min: u8 = 50;
+        let max: u8 = 90;
         
-        // Generate random u32 numbers
-        let random1 = PseudoRandom::generate_random_u32(1, 1000, 0);
-        let random2 = PseudoRandom::generate_random_u32(1, 1000, 1);
+        // Generate values for different attributes of the same beast
+        let hunger = PseudoRandom::generate_random_u8(beast_id, 1, min, max);
+        let energy = PseudoRandom::generate_random_u8(beast_id, 2, min, max);
+        let happiness = PseudoRandom::generate_random_u8(beast_id, 3, min, max);
+        let hygiene = PseudoRandom::generate_random_u8(beast_id, 4, min, max);
         
-        // Check that values are within the specified range
-        assert(random1 >= 1 && random1 <= 1000, 'Value out of range 1-1000');
-        assert(random2 >= 1 && random2 <= 1000, 'Value out of range 1-1000');
+        // Check that values are within range
+        assert(hunger >= min && hunger <= max, 'Hunger out of range');
+        assert(energy >= min && energy <= max, 'Energy out of range');
+        assert(happiness >= min && happiness <= max, 'Happiness out of range');
+        assert(hygiene >= min && hygiene <= max, 'Hygiene out of range');
         
-        // Different salts should produce different results
-        assert(random1 != random2, 'Different salts -> different values');
+        // It's likely that at least some values are different
+        let all_equal = hunger == energy && energy == happiness && happiness == hygiene;
+        assert(!all_equal, 'All attributes are the same');
     }
     
     #[test]
-    fn test_generate_random_u64() {
-        // Set deterministic block values for testing
-        set_block_timestamp(1000);
-        set_block_number(500);
+    #[available_gas(300000)]
+    fn test_consistency() {
+        // Test that the same inputs produce the same outputs
+        let beast_id = 5_u16;
+        let attribute_salt = 3_u16;
+        let min: u8 = 50;
+        let max: u8 = 90;
         
-        // Generate random u64 numbers
-        let random1 = PseudoRandom::generate_random_u64(1, 10000, 0);
-        let random2 = PseudoRandom::generate_random_u64(1, 10000, 2);
+        let value1 = PseudoRandom::generate_random_u8(beast_id, attribute_salt, min, max);
+        let value2 = PseudoRandom::generate_random_u8(beast_id, attribute_salt, min, max);
         
-        // Check that values are within the specified range
-        assert(random1 >= 1 && random1 <= 10000, 'Value out of range 1-10000');
-        assert(random2 >= 1 && random2 <= 10000, 'Value out of range 1-10000');
-        
-        // Different salts should produce different results
-        assert(random1 != random2, 'Different salts -> different values');
-    }
-    
-    #[test]
-    #[should_panic(expected: ('Min must be <= max',))]
-    fn test_invalid_range() {
-        // This should panic because min > max
-        PseudoRandom::generate_random_u8(100, 50, 0);
+        // Same inputs should give same outputs
+        assert(value1 == value2, 'Random values not consistent');
     }
 } 

--- a/contract/src/systems/actions.cairo
+++ b/contract/src/systems/actions.cairo
@@ -1,0 +1,33 @@
+use starknet::ContractAddress;
+use starkfantasy::helpers::pseudo_random::PseudoRandom;
+
+#[starknet::interface]
+trait IActions<TContractState> {
+    fn simulate_random_draw(self: @TContractState, salt: felt252) -> u8;
+}
+
+#[dojo::contract]
+mod actions {
+    use starknet::ContractAddress;
+    use starkfantasy::helpers::pseudo_random::PseudoRandom;
+
+    #[abi(embed_v0)]
+    impl ActionsImpl of super::IActions<ContractState> {
+        /// Simulates a random draw using the PseudoRandom helper
+        /// 
+        /// # Arguments
+        /// 
+        /// * `salt` - An optional salt to add more entropy
+        /// 
+        /// # Returns
+        /// 
+        /// A random number between 1 and 100
+        fn simulate_random_draw(self: @ContractState, salt: felt252) -> u8 {
+            // Generate a random number between 1 and 100
+            let random_number = PseudoRandom::generate_random_u8(1, 100, salt);
+            
+            // Return the random number
+            random_number
+        }
+    }
+}


### PR DESCRIPTION
Closes #56

This PR implements a pseudo-random number generator helper in the helpers folder to provide deterministic randomness for Dojo games.

Changes:
- Added `pseudo_random.cairo` with the `PseudoRandom` module
- Implemented random generation functions for u8, u32, and u64 types
- Added comprehensive tests and documentation
- Updated lib.cairo to expose the module
- Added sample usage in actions.cairo

The implementation meets all acceptance criteria specified in the issue.